### PR TITLE
wave: support using Graphene Unions with mixed Strawberry/Graphene types

### DIFF
--- a/graphene/__init__.py
+++ b/graphene/__init__.py
@@ -29,7 +29,7 @@ from .types import (
 from .utils.module_loading import lazy_import
 from .utils.resolve_only_args import resolve_only_args
 
-VERSION = (0, 1, 1, "final", 0)
+VERSION = (0, 1, 2, "final", 0)
 
 
 __version__ = get_version(VERSION)

--- a/graphene/types/schema.py
+++ b/graphene/types/schema.py
@@ -396,6 +396,11 @@ class TypeMap(dict):
 
         if inspect.isclass(type_) and issubclass(type_, ObjectType):
             return type_._meta.name
+        if (
+            (strawberry_definition := getattr(type_, "_type_definition", None))
+            is not None
+        ) and (name := getattr(strawberry_definition, "name", None)) is not None:
+            return name
 
         return_type = self[type_name]
         return default_type_resolver(root, info, return_type)

--- a/graphene/types/union.py
+++ b/graphene/types/union.py
@@ -74,3 +74,5 @@ class Union(UnmountedType, BaseType):
 
         if isinstance(instance, ObjectType):
             return type(instance)
+        if hasattr(instance, "_type_definition"):
+            return type(instance)


### PR DESCRIPTION
With this you can use graphene.Union that has a Strawberry type in it. Note that the reverse is not true - you still cannot have a Strawberry union that holds Graphene types.